### PR TITLE
Adds a new monster flag MF_RESPECT_MON_AVOID

### DIFF
--- a/src/mtype.h
+++ b/src/mtype.h
@@ -153,6 +153,7 @@ enum m_flag : int {
     MF_AVOID_DANGER_2,      // This monster will path around most dangers instead of through them.
     MF_PRIORITIZE_TARGETS,  // This monster will prioritize targets depending on their danger levels
     MF_NOT_HALLU,           // Monsters that will NOT appear when player's producing hallucinations
+    MF_RESPECT_MON_AVOID,        // This monster will be unable to enter a tile with the flag MON_AVOID
     MF_MAX                  // Sets the length of the flags - obviously must be LAST
 };
 


### PR DESCRIPTION
Adds a new monster flag MF_RESPECT_MON_AVOID, When used with the new terrain flag MON_AVOID the monmove.cpp(monster::can_move_to) will always return false. Can be used for various things including mods. such as a force-field(supernatural or scientific) as a way to ward against a single monster or single monster type from being able to cross, while enabling everything else to use it as normal.