### PR TITLE
added MON_AVOID to be used with MF_RESPECTAVOID

### DIFF
--- a/src/mapdata.h
+++ b/src/mapdata.h
@@ -179,7 +179,7 @@ enum ter_bitflags : int {
     TFLAG_NO_FLOOR,
     TFLAG_SEEN_FROM_ABOVE,
     TFLAG_RAMP,
-    MON_AVOID,
+    TFLAG_MON_AVOID,
     NUM_TERFLAGS
 };
 

--- a/src/mapdata.h
+++ b/src/mapdata.h
@@ -179,7 +179,7 @@ enum ter_bitflags : int {
     TFLAG_NO_FLOOR,
     TFLAG_SEEN_FROM_ABOVE,
     TFLAG_RAMP,
-
+    MON_AVOID,
     NUM_TERFLAGS
 };
 


### PR DESCRIPTION
Added MON_AVOID to be used with MF_RESPECT_MON_AVOID (Monsters with MF_RESPECT_MON_AVOID will not be able to enter a tile with this flag), Can be used to single out monsters with this tag from being able cross/enter this tile. Can be used to ward against/create a barrier/force-field specifically targeted to only monsters with MF_RESPECT_MON_AVOID.